### PR TITLE
Fix Issue #8, Use LocalSymbolMap instead of FunctionPrototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ and other loader features it uses.
 The current tool is implemented as a Ghidra script. It leverages Ghidra's
 intermediate language and data dependency analysis to discover struct fields,
 and outputs its results to the Ghidra Data Type Manager. See
-[the associated blog post](https://blog.grimm-co.com/) for more information.
+[the associated blog post](https://blog.grimm-co.com/2020/11/automated-struct-identification-with.html)
+for more information.
 
 ## References of interest:
 

--- a/plugin/PCodeInterpreter.py
+++ b/plugin/PCodeInterpreter.py
@@ -587,7 +587,7 @@ def checkFixParameters(func, parameters):
 	for i in range(func_proto.getNumParams()):
 		cur = func_proto.getParam(i).getRepresentative()
 		if cur.getSize() != parameters[i].getSize():
-			print(cur.getSize(), parameters[i].getSize())
+			print("i: %d, cur.getSize: %d, parameters[i].getSize(): %d" % (i, cur.getSize(), parameters[i].getSize()))
 			raise Exception("Func parameter size mismatch")	
 
 # Make sure func signature matches the call

--- a/plugin/PCodeInterpreter.py
+++ b/plugin/PCodeInterpreter.py
@@ -594,7 +594,6 @@ def checkFixParameters(func, parameters):
 def checkFixReturn(func, ret_varnode):
 	hf = get_highfunction(func)
 
-	func_proto = hf.getFunctionPrototype()
 	#  Check return types
 	for i in hf.getPcodeOps():
 		if i.getOpcode() == PcodeOp.RETURN:
@@ -612,7 +611,7 @@ def analyzeFunctionBackward(func, pci, init_param=None):
 	hf = get_highfunction(func)
 	HighFunctionDBUtil.commitParamsToDatabase(hf, True, SourceType.DEFAULT)
 
-	func_proto = hf.getFunctionPrototype()
+	func_proto = hf.getLocalSymbolMap()
 	# Grab return varnodes
 	return_varnodes = []
 	for i in hf.getPcodeOps():

--- a/plugin/PCodeInterpreter.py
+++ b/plugin/PCodeInterpreter.py
@@ -578,7 +578,7 @@ def checkFixParameters(func, parameters):
 	hf = get_highfunction(func)
 
 	# Check arguments
-	func_proto = hf.getFunctionPrototype()
+	func_proto = hf.getLocalSymbolMap()
 	if func_proto.getNumParams() != len(parameters) and not func.hasVarArgs():
 		print(func, "call signature wrong...")
 		raise Exception("Function call signature different")
@@ -656,7 +656,7 @@ def analyzeFunctionForward(func, pci):
 	print(func.getParameters())
 
 	# get the varnode of function parameters
-	func_proto = hf.getFunctionPrototype()
+	func_proto = hf.getLocalSymbolMap()
 	argument_varnodes = []
 	argument_nodes = []
 	for i in range(func_proto.getNumParams()):


### PR DESCRIPTION
This fixes #8 , where switching to a LocalSymbolMap resolved the error `AttributeError: 'ghidra.program.model.pcode.HighSymbol' object has no attribute 'getRepresentative'`.

Tested on Ghidra version 9.2 (`9.2_PUBLIC_20201113`) on MacOS.